### PR TITLE
Cleanup the usings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ export_presets.cfg
 # Mono-specific ignores
 .mono/
 data_*/
+.vs/
 
 .godot/
 

--- a/src/Components/GetMoreSkinsContainer.cs
+++ b/src/Components/GetMoreSkinsContainer.cs
@@ -1,5 +1,3 @@
-using Godot;
-
 namespace OsuSkinMixer.Components;
 
 public partial class GetMoreSkinsContainer : PanelContainer

--- a/src/Components/OperationComponent.cs
+++ b/src/Components/OperationComponent.cs
@@ -1,7 +1,7 @@
+namespace OsuSkinMixer.Components;
+
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
-
-namespace OsuSkinMixer.Components;
 
 public partial class OperationComponent : HBoxContainer
 {

--- a/src/Components/OperationComponent.cs
+++ b/src/Components/OperationComponent.cs
@@ -1,5 +1,3 @@
-using Godot;
-using System;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
 

--- a/src/Components/Osu/ComboContainer.cs
+++ b/src/Components/Osu/ComboContainer.cs
@@ -1,6 +1,4 @@
-using Godot;
 using OsuSkinMixer.Models;
-using System;
 using System.IO;
 
 namespace OsuSkinMixer.Components;

--- a/src/Components/Osu/ComboContainer.cs
+++ b/src/Components/Osu/ComboContainer.cs
@@ -1,7 +1,7 @@
+namespace OsuSkinMixer.Components;
+
 using OsuSkinMixer.Models;
 using System.IO;
-
-namespace OsuSkinMixer.Components;
 
 public partial class ComboContainer : HBoxContainer
 {

--- a/src/Components/Osu/Hitcircle.cs
+++ b/src/Components/Osu/Hitcircle.cs
@@ -1,6 +1,6 @@
-using OsuSkinMixer.Models;
-
 namespace OsuSkinMixer.Components;
+
+using OsuSkinMixer.Models;
 
 public partial class Hitcircle : Node2D
 {

--- a/src/Components/Osu/Hitcircle.cs
+++ b/src/Components/Osu/Hitcircle.cs
@@ -1,5 +1,3 @@
-using System;
-using Godot;
 using OsuSkinMixer.Models;
 
 namespace OsuSkinMixer.Components;

--- a/src/Components/Osu/HitcircleIcon.cs
+++ b/src/Components/Osu/HitcircleIcon.cs
@@ -1,4 +1,3 @@
-using Godot;
 using OsuSkinMixer.Models;
 
 namespace OsuSkinMixer.Components;

--- a/src/Components/Osu/HitcircleIcon.cs
+++ b/src/Components/Osu/HitcircleIcon.cs
@@ -1,6 +1,6 @@
-using OsuSkinMixer.Models;
-
 namespace OsuSkinMixer.Components;
+
+using OsuSkinMixer.Models;
 
 public partial class HitcircleIcon : CenterContainer
 {

--- a/src/Components/Osu/SkinPreview.cs
+++ b/src/Components/Osu/SkinPreview.cs
@@ -1,4 +1,3 @@
-using Godot;
 using OsuSkinMixer.Models;
 using System.IO;
 using OsuSkinMixer.Statics;

--- a/src/Components/Osu/SkinPreview.cs
+++ b/src/Components/Osu/SkinPreview.cs
@@ -1,9 +1,9 @@
+namespace OsuSkinMixer.Components;
+
 using OsuSkinMixer.Models;
 using System.IO;
 using OsuSkinMixer.Statics;
 using SixLabors.ImageSharp;
-
-namespace OsuSkinMixer.Components;
 
 public partial class SkinPreview : PanelContainer
 {

--- a/src/Components/Popup/Base/Popup.cs
+++ b/src/Components/Popup/Base/Popup.cs
@@ -1,6 +1,3 @@
-using System;
-using Godot;
-
 namespace OsuSkinMixer.Components;
 
 public abstract partial class Popup : Control

--- a/src/Components/Popup/ChangelogPopup.cs
+++ b/src/Components/Popup/ChangelogPopup.cs
@@ -1,4 +1,3 @@
-using Godot;
 using OsuSkinMixer.Statics;
 
 namespace OsuSkinMixer.Components;

--- a/src/Components/Popup/ChangelogPopup.cs
+++ b/src/Components/Popup/ChangelogPopup.cs
@@ -1,6 +1,6 @@
-using OsuSkinMixer.Statics;
-
 namespace OsuSkinMixer.Components;
+
+using OsuSkinMixer.Statics;
 
 public partial class ChangelogPopup : Popup
 {

--- a/src/Components/Popup/Generic/LoadingPopup.cs
+++ b/src/Components/Popup/Generic/LoadingPopup.cs
@@ -1,6 +1,3 @@
-using Godot;
-using System;
-
 namespace OsuSkinMixer.Components;
 
 public partial class LoadingPopup : Popup

--- a/src/Components/Popup/Generic/OkPopup.cs
+++ b/src/Components/Popup/Generic/OkPopup.cs
@@ -1,5 +1,3 @@
-using Godot;
-
 namespace OsuSkinMixer.Components;
 
 public partial class OkPopup : Popup

--- a/src/Components/Popup/Generic/QuestionPopup.cs
+++ b/src/Components/Popup/Generic/QuestionPopup.cs
@@ -1,6 +1,3 @@
-using Godot;
-using System;
-
 namespace OsuSkinMixer.Components;
 
 public partial class QuestionPopup : Popup

--- a/src/Components/Popup/GetMoreSkinsPopup.cs
+++ b/src/Components/Popup/GetMoreSkinsPopup.cs
@@ -1,5 +1,3 @@
-using Godot;
-
 namespace OsuSkinMixer.Components;
 
 public partial class GetMoreSkinsPopup : Popup

--- a/src/Components/Popup/HistoryPopup.cs
+++ b/src/Components/Popup/HistoryPopup.cs
@@ -1,6 +1,6 @@
-using OsuSkinMixer.Statics;
-
 namespace OsuSkinMixer.Components;
+
+using OsuSkinMixer.Statics;
 
 public partial class HistoryPopup : Popup
 {

--- a/src/Components/Popup/HistoryPopup.cs
+++ b/src/Components/Popup/HistoryPopup.cs
@@ -1,6 +1,4 @@
-using Godot;
 using OsuSkinMixer.Statics;
-using System.Linq;
 
 namespace OsuSkinMixer.Components;
 

--- a/src/Components/Popup/ManageSkinPopup.cs
+++ b/src/Components/Popup/ManageSkinPopup.cs
@@ -1,12 +1,7 @@
-using Godot;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
-using System.Threading.Tasks;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
-using System;
 
 namespace OsuSkinMixer.Components;
 

--- a/src/Components/Popup/ManageSkinPopup.cs
+++ b/src/Components/Popup/ManageSkinPopup.cs
@@ -1,9 +1,9 @@
+namespace OsuSkinMixer.Components;
+
 using System.IO;
 using System.IO.Compression;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
-
-namespace OsuSkinMixer.Components;
 
 public partial class ManageSkinPopup : Popup
 {

--- a/src/Components/Popup/ResolveSkinConflictPopup.cs
+++ b/src/Components/Popup/ResolveSkinConflictPopup.cs
@@ -1,7 +1,7 @@
+namespace OsuSkinMixer.Components;
+
 using System.IO;
 using OsuSkinMixer.Statics;
-
-namespace OsuSkinMixer.Components;
 
 public partial class ResolveSkinConflictPopup : Popup
 {

--- a/src/Components/Popup/ResolveSkinConflictPopup.cs
+++ b/src/Components/Popup/ResolveSkinConflictPopup.cs
@@ -1,4 +1,3 @@
-using Godot;
 using System.IO;
 using OsuSkinMixer.Statics;
 

--- a/src/Components/Popup/SettingsPopup.cs
+++ b/src/Components/Popup/SettingsPopup.cs
@@ -1,8 +1,8 @@
+namespace OsuSkinMixer.Components;
+
 using System.IO;
 using System.Diagnostics;
 using OsuSkinMixer.Statics;
-
-namespace OsuSkinMixer.Components;
 
 public partial class SettingsPopup : Popup
 {

--- a/src/Components/Popup/SettingsPopup.cs
+++ b/src/Components/Popup/SettingsPopup.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Diagnostics;
-using Godot;
 using OsuSkinMixer.Statics;
 
 namespace OsuSkinMixer.Components;

--- a/src/Components/Popup/SetupPopup.cs
+++ b/src/Components/Popup/SetupPopup.cs
@@ -1,9 +1,9 @@
+namespace OsuSkinMixer.Components;
+
 using Environment = System.Environment;
 using OsuSkinMixer.Statics;
 using System.Threading.Tasks;
 using System.IO;
-
-namespace OsuSkinMixer.Components;
 
 public partial class SetupPopup : Popup
 {

--- a/src/Components/Popup/SetupPopup.cs
+++ b/src/Components/Popup/SetupPopup.cs
@@ -1,4 +1,3 @@
-using Godot;
 using Environment = System.Environment;
 using OsuSkinMixer.Statics;
 using System.Threading.Tasks;

--- a/src/Components/Popup/SkinNamePopup.cs
+++ b/src/Components/Popup/SkinNamePopup.cs
@@ -1,7 +1,4 @@
-using Godot;
-using System;
 using System.IO;
-using System.Linq;
 using OsuSkinMixer.Statics;
 
 namespace OsuSkinMixer.Components;

--- a/src/Components/Popup/SkinNamePopup.cs
+++ b/src/Components/Popup/SkinNamePopup.cs
@@ -1,7 +1,7 @@
+namespace OsuSkinMixer.Components;
+
 using System.IO;
 using OsuSkinMixer.Statics;
-
-namespace OsuSkinMixer.Components;
 
 public partial class SkinNamePopup : Popup
 {

--- a/src/Components/Popup/SkinSelectorPopup.cs
+++ b/src/Components/Popup/SkinSelectorPopup.cs
@@ -1,7 +1,7 @@
+namespace OsuSkinMixer.Components;
+
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
-
-namespace OsuSkinMixer.Components;
 
 public partial class SkinSelectorPopup : Popup
 {

--- a/src/Components/Popup/SkinSelectorPopup.cs
+++ b/src/Components/Popup/SkinSelectorPopup.cs
@@ -1,8 +1,5 @@
-using Godot;
-using System;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
-using System.Collections.Generic;
 
 namespace OsuSkinMixer.Components;
 

--- a/src/Components/SkinComponent.cs
+++ b/src/Components/SkinComponent.cs
@@ -1,5 +1,3 @@
-using System;
-using Godot;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
 

--- a/src/Components/SkinComponent.cs
+++ b/src/Components/SkinComponent.cs
@@ -1,7 +1,7 @@
+namespace OsuSkinMixer.Components;
+
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
-
-namespace OsuSkinMixer.Components;
 
 public partial class SkinComponent : HBoxContainer
 {

--- a/src/Components/SkinComponentsContainer.cs
+++ b/src/Components/SkinComponentsContainer.cs
@@ -1,9 +1,5 @@
-using Godot;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace OsuSkinMixer.Components;
 

--- a/src/Components/SkinComponentsContainer.cs
+++ b/src/Components/SkinComponentsContainer.cs
@@ -1,7 +1,7 @@
+namespace OsuSkinMixer.Components;
+
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
-
-namespace OsuSkinMixer.Components;
 
 public partial class SkinComponentsContainer : PanelContainer
 {

--- a/src/Components/SkinInfoPanel.cs
+++ b/src/Components/SkinInfoPanel.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Linq;
-using Godot;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
 

--- a/src/Components/SkinInfoPanel.cs
+++ b/src/Components/SkinInfoPanel.cs
@@ -1,7 +1,7 @@
+namespace OsuSkinMixer.Components;
+
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
-
-namespace OsuSkinMixer.Components;
 
 public partial class SkinInfoPanel : PanelContainer
 {

--- a/src/Components/SkinOptionsSelector/SkinOptionComponent.cs
+++ b/src/Components/SkinOptionsSelector/SkinOptionComponent.cs
@@ -1,6 +1,6 @@
-using OsuSkinMixer.Models;
-
 namespace OsuSkinMixer.Components;
+
+using OsuSkinMixer.Models;
 
 public partial class SkinOptionComponent : HBoxContainer
 {

--- a/src/Components/SkinOptionsSelector/SkinOptionComponent.cs
+++ b/src/Components/SkinOptionsSelector/SkinOptionComponent.cs
@@ -1,4 +1,3 @@
-using Godot;
 using OsuSkinMixer.Models;
 
 namespace OsuSkinMixer.Components;

--- a/src/Components/SkinOptionsSelector/SkinOptionsSelector.cs
+++ b/src/Components/SkinOptionsSelector/SkinOptionsSelector.cs
@@ -1,7 +1,7 @@
+namespace OsuSkinMixer.Components;
+
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
-
-namespace OsuSkinMixer.Components;
 
 public partial class SkinOptionsSelector : PanelContainer
 {

--- a/src/Components/SkinOptionsSelector/SkinOptionsSelector.cs
+++ b/src/Components/SkinOptionsSelector/SkinOptionsSelector.cs
@@ -1,7 +1,3 @@
-using Godot;
-using System.Collections.Generic;
-using System.Linq;
-using System;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
 

--- a/src/Components/SkinSortChipsContainer.cs
+++ b/src/Components/SkinSortChipsContainer.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Linq;
-using Godot;
 using OsuSkinMixer.Models;
 
 namespace OsuSkinMixer;

--- a/src/Components/SkinSortChipsContainer.cs
+++ b/src/Components/SkinSortChipsContainer.cs
@@ -1,6 +1,6 @@
-using OsuSkinMixer.Models;
-
 namespace OsuSkinMixer;
+
+using OsuSkinMixer.Models;
 
 public partial class SkinSortChipsContainer : HBoxContainer
 {

--- a/src/Components/Toast.cs
+++ b/src/Components/Toast.cs
@@ -1,6 +1,3 @@
-using Godot;
-using System.Collections.Generic;
-
 namespace OsuSkinMixer.Components;
 
 public partial class Toast : Control

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -6,13 +6,13 @@ global using System.Threading.Tasks;
 global using System.Collections.Generic;
 global using System.Collections.Concurrent;
 
+namespace OsuSkinMixer;
+
 using OsuSkinMixer.Components;
 using OsuSkinMixer.Statics;
 using OsuSkinMixer.StackScenes;
 using OsuSkinMixer.Models;
 using System.IO;
-
-namespace OsuSkinMixer;
 
 public partial class Main : Control
 {

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -1,11 +1,15 @@
-using Godot;
-using System.Collections.Generic;
+global using Godot;
+global using System;
+global using System.Linq;
+global using System.Threading;
+global using System.Threading.Tasks;
+global using System.Collections.Generic;
+global using System.Collections.Concurrent;
+
 using OsuSkinMixer.Components;
 using OsuSkinMixer.Statics;
 using OsuSkinMixer.StackScenes;
 using OsuSkinMixer.Models;
-using System.Linq;
-using System.Threading.Tasks;
 using System.IO;
 
 namespace OsuSkinMixer;

--- a/src/Models/GithubRelease.cs
+++ b/src/Models/GithubRelease.cs
@@ -1,6 +1,6 @@
-using System.Text.Json.Serialization;
-
 namespace OsuSkinMixer.Models;
+
+using System.Text.Json.Serialization;
 
 public class GithubRelease
 {

--- a/src/Models/ManageSkinOptions.cs
+++ b/src/Models/ManageSkinOptions.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace OsuSkinMixer.Models;
 
 [Flags]

--- a/src/Models/Operation.cs
+++ b/src/Models/Operation.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using OsuSkinMixer.Statics;
 
 namespace OsuSkinMixer.Models;

--- a/src/Models/Operation.cs
+++ b/src/Models/Operation.cs
@@ -1,7 +1,7 @@
+namespace OsuSkinMixer.Models;
+
 using System.Text.Json.Serialization;
 using OsuSkinMixer.Statics;
-
-namespace OsuSkinMixer.Models;
 
 /// <summary>
 /// A class that represents an operation to be peformed to a single skin.

--- a/src/Models/Osu/OsuSkin.cs
+++ b/src/Models/Osu/OsuSkin.cs
@@ -1,8 +1,8 @@
+namespace OsuSkinMixer.Models;
+
 using System.IO;
 using OsuSkinMixer.Statics;
 using File = System.IO.File;
-
-namespace OsuSkinMixer.Models;
 
 /// <summary>Represents an osu! skin and provides methods to fetch its elements.</summary>
 public class OsuSkin

--- a/src/Models/Osu/OsuSkin.cs
+++ b/src/Models/Osu/OsuSkin.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.IO;
-using Godot;
 using OsuSkinMixer.Statics;
 using File = System.IO.File;
 

--- a/src/Models/Osu/OsuSkinIni.cs
+++ b/src/Models/Osu/OsuSkinIni.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Linq;
-using System.Collections.Generic;
 using OsuSkinMixer.Statics;
 
 namespace OsuSkinMixer.Models;

--- a/src/Models/Osu/OsuSkinIni.cs
+++ b/src/Models/Osu/OsuSkinIni.cs
@@ -1,6 +1,6 @@
-using OsuSkinMixer.Statics;
-
 namespace OsuSkinMixer.Models;
+
+using OsuSkinMixer.Statics;
 
 /// <summary>Represents a osu! skin's skin.ini file.</summary>
 public class OsuSkinIni

--- a/src/Models/Osu/OsuSkinIniSection.cs
+++ b/src/Models/Osu/OsuSkinIniSection.cs
@@ -1,6 +1,6 @@
-using System.Text;
-
 namespace OsuSkinMixer.Models;
+
+using System.Text;
 
 /// <summary>Represents a section in a osu! skin's skin.ini file, such as "[General]", with its values represented as key-value pairs.</summary>
 public class OsuSkinIniSection : Dictionary<string, string>

--- a/src/Models/Osu/OsuSkinIniSection.cs
+++ b/src/Models/Osu/OsuSkinIniSection.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Text;
 
 namespace OsuSkinMixer.Models;

--- a/src/Models/SettingsContent.cs
+++ b/src/Models/SettingsContent.cs
@@ -1,7 +1,7 @@
+namespace OsuSkinMixer.Statics;
+
 using System.Text.Json.Serialization;
 using OsuSkinMixer.Models;
-
-namespace OsuSkinMixer.Statics;
 
 public static partial class Settings
 {

--- a/src/Models/SettingsContent.cs
+++ b/src/Models/SettingsContent.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using OsuSkinMixer.Models;
 

--- a/src/Models/SkinOptions/ParentSkinOption.cs
+++ b/src/Models/SkinOptions/ParentSkinOption.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-
 namespace OsuSkinMixer.Models;
 
 /// <summary>Represents a skin option category that acts as a parent of one or more skin options. It does not target any skin elements on its own.</summary>

--- a/src/Models/SkinOptions/SkinIniSectionOption.cs
+++ b/src/Models/SkinOptions/SkinIniSectionOption.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace OsuSkinMixer.Models;
 
 /// <summary>Represents an option with the target of an entire skin.ini section which contains a matching <see cref="Property"/> key-pair value.</summary>

--- a/src/Models/SkinOptions/SkinOption.cs
+++ b/src/Models/SkinOptions/SkinOption.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace OsuSkinMixer.Models;
 
 /// <summary>Base class for all skin options.</summary>

--- a/src/Splash.cs
+++ b/src/Splash.cs
@@ -1,9 +1,9 @@
+namespace OsuSkinMixer;
+
 using OsuSkinMixer.Components;
 using OsuSkinMixer.Statics;
 using System.Diagnostics;
 using System.IO;
-
-namespace OsuSkinMixer;
 
 public partial class Splash : Control
 {

--- a/src/Splash.cs
+++ b/src/Splash.cs
@@ -1,10 +1,7 @@
-using Godot;
 using OsuSkinMixer.Components;
 using OsuSkinMixer.Statics;
-using System;
 using System.Diagnostics;
 using System.IO;
-using System.Threading.Tasks;
 
 namespace OsuSkinMixer;
 

--- a/src/StackScenes/Menu.cs
+++ b/src/StackScenes/Menu.cs
@@ -1,5 +1,3 @@
-using System;
-using Godot;
 using OsuSkinMixer.Components;
 using OsuSkinMixer.Statics;
 

--- a/src/StackScenes/Menu.cs
+++ b/src/StackScenes/Menu.cs
@@ -1,7 +1,7 @@
+namespace OsuSkinMixer.StackScenes;
+
 using OsuSkinMixer.Components;
 using OsuSkinMixer.Statics;
-
-namespace OsuSkinMixer.StackScenes;
 
 public partial class Menu : StackScene
 {

--- a/src/StackScenes/SkinInfo.cs
+++ b/src/StackScenes/SkinInfo.cs
@@ -1,7 +1,7 @@
+namespace OsuSkinMixer.StackScenes;
+
 using OsuSkinMixer.Components;
 using OsuSkinMixer.Models;
-
-namespace OsuSkinMixer.StackScenes;
 
 public partial class SkinInfo : StackScene
 {

--- a/src/StackScenes/SkinInfo.cs
+++ b/src/StackScenes/SkinInfo.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using Godot;
 using OsuSkinMixer.Components;
 using OsuSkinMixer.Models;
 

--- a/src/StackScenes/SkinManager.cs
+++ b/src/StackScenes/SkinManager.cs
@@ -1,6 +1,3 @@
-using System.Linq;
-using System.Collections.Generic;
-using Godot;
 using OsuSkinMixer.Components;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;

--- a/src/StackScenes/SkinManager.cs
+++ b/src/StackScenes/SkinManager.cs
@@ -1,8 +1,8 @@
+namespace OsuSkinMixer.StackScenes;
+
 using OsuSkinMixer.Components;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
-
-namespace OsuSkinMixer.StackScenes;
 
 public partial class SkinManager : StackScene
 {

--- a/src/StackScenes/SkinMixer.cs
+++ b/src/StackScenes/SkinMixer.cs
@@ -1,10 +1,10 @@
+namespace OsuSkinMixer.StackScenes;
+
 using OsuSkinMixer.Components;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Utils;
 using OsuSkinMixer.Statics;
 using System.IO;
-
-namespace OsuSkinMixer.StackScenes;
 
 public partial class SkinMixer : StackScene
 {

--- a/src/StackScenes/SkinMixer.cs
+++ b/src/StackScenes/SkinMixer.cs
@@ -1,5 +1,3 @@
-using Godot;
-using System.Threading;
 using OsuSkinMixer.Components;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Utils;

--- a/src/StackScenes/SkinModifierModificationSelect.cs
+++ b/src/StackScenes/SkinModifierModificationSelect.cs
@@ -1,8 +1,3 @@
-using Godot;
-using System;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using OsuSkinMixer.Components;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Utils;

--- a/src/StackScenes/SkinModifierModificationSelect.cs
+++ b/src/StackScenes/SkinModifierModificationSelect.cs
@@ -1,9 +1,9 @@
+namespace OsuSkinMixer.StackScenes;
+
 using OsuSkinMixer.Components;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Utils;
 using OsuSkinMixer.Statics;
-
-namespace OsuSkinMixer.StackScenes;
 
 public partial class SkinModifierModificationSelect : StackScene
 {

--- a/src/StackScenes/SkinModifierSkinSelect.cs
+++ b/src/StackScenes/SkinModifierSkinSelect.cs
@@ -1,8 +1,8 @@
+namespace OsuSkinMixer.StackScenes;
+
 using OsuSkinMixer.Components;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
-
-namespace OsuSkinMixer.StackScenes;
 
 public partial class SkinModifierSkinSelect : StackScene
 {

--- a/src/StackScenes/SkinModifierSkinSelect.cs
+++ b/src/StackScenes/SkinModifierSkinSelect.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-using Godot;
 using OsuSkinMixer.Components;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;

--- a/src/StackScenes/StackScene.cs
+++ b/src/StackScenes/StackScene.cs
@@ -1,5 +1,3 @@
-using Godot;
-
 namespace OsuSkinMixer.StackScenes;
 
 public abstract partial class StackScene : Container

--- a/src/Statics/ExtensionMethods.cs
+++ b/src/Statics/ExtensionMethods.cs
@@ -1,6 +1,6 @@
-using System.IO;
-
 namespace OsuSkinMixer.Statics;
+
+using System.IO;
 
 public static class ExtensionMethods
 {

--- a/src/Statics/ExtensionMethods.cs
+++ b/src/Statics/ExtensionMethods.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 
 namespace OsuSkinMixer.Statics;

--- a/src/Statics/OsuData.cs
+++ b/src/Statics/OsuData.cs
@@ -1,9 +1,4 @@
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using Godot;
 using OsuSkinMixer.Models;
 
 namespace OsuSkinMixer.Statics;

--- a/src/Statics/OsuData.cs
+++ b/src/Statics/OsuData.cs
@@ -1,7 +1,7 @@
+namespace OsuSkinMixer.Statics;
+
 using System.IO;
 using OsuSkinMixer.Models;
-
-namespace OsuSkinMixer.Statics;
 
 /// <summary>
 /// A static class that provides other objects with the user's osu! data, such as their list of skins.

--- a/src/Statics/Settings.cs
+++ b/src/Statics/Settings.cs
@@ -1,3 +1,5 @@
+namespace OsuSkinMixer.Statics;
+
 using System.IO;
 using System.Reflection;
 using System.Text.Json;
@@ -5,8 +7,6 @@ using File = System.IO.File;
 using Directory = System.IO.Directory;
 using HttpClient = System.Net.Http.HttpClient;
 using OsuSkinMixer.Models;
-
-namespace OsuSkinMixer.Statics;
 
 public static partial class Settings
 {

--- a/src/Statics/Settings.cs
+++ b/src/Statics/Settings.cs
@@ -1,9 +1,6 @@
-using Godot;
-using System;
 using System.IO;
 using System.Reflection;
 using System.Text.Json;
-using System.Threading.Tasks;
 using File = System.IO.File;
 using Directory = System.IO.Directory;
 using HttpClient = System.Net.Http.HttpClient;

--- a/src/Statics/Tools.cs
+++ b/src/Statics/Tools.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Diagnostics;
 using System.IO;
-using Godot;
 using OsuSkinMixer.Models;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;

--- a/src/Statics/Tools.cs
+++ b/src/Statics/Tools.cs
@@ -1,11 +1,11 @@
+namespace OsuSkinMixer.Statics;
+
 using System.Diagnostics;
 using System.IO;
 using OsuSkinMixer.Models;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using File = System.IO.File;
-
-namespace OsuSkinMixer.Statics;
 
 public static class Tools
 {

--- a/src/Utils/SkinMachine.cs
+++ b/src/Utils/SkinMachine.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading;
-using Godot;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
 

--- a/src/Utils/SkinMachine.cs
+++ b/src/Utils/SkinMachine.cs
@@ -1,10 +1,10 @@
+namespace OsuSkinMixer.Utils;
+
 using System.Diagnostics;
 using System.IO;
 using System.Text;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
-
-namespace OsuSkinMixer.Utils;
 
 /// <summary>Base for classes that peform tasks based on a list of <see cref="SkinOption"/>. Provides abstract methods for populating tasks to be peformed on the relevant skin folders.</summary>
 public abstract class SkinMachine : IDisposable

--- a/src/Utils/SkinMixerMachine.cs
+++ b/src/Utils/SkinMixerMachine.cs
@@ -1,8 +1,4 @@
-using System;
 using System.IO;
-using System.Linq;
-using System.Threading;
-using Godot;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
 

--- a/src/Utils/SkinMixerMachine.cs
+++ b/src/Utils/SkinMixerMachine.cs
@@ -1,8 +1,8 @@
+namespace OsuSkinMixer.Utils;
+
 using System.IO;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
-
-namespace OsuSkinMixer.Utils;
 
 /// <summary>Provides methods to create and import a new skin from a list of <see cref="SkinOption"/>.</summary>
 public class SkinMixerMachine : SkinMachine

--- a/src/Utils/SkinModifierMachine.cs
+++ b/src/Utils/SkinModifierMachine.cs
@@ -1,3 +1,5 @@
+namespace OsuSkinMixer.Utils;
+
 using System.IO;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Processing;
@@ -6,8 +8,6 @@ using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
 using Image = SixLabors.ImageSharp.Image;
 using Color = SixLabors.ImageSharp.Color;
-
-namespace OsuSkinMixer.Utils;
 
 /// <summary>Provides methods to modify one or more skins based on a list of <see cref="SkinOption"/> and extra flags.</summary>
 public class SkinModifierMachine : SkinMachine

--- a/src/Utils/SkinModifierMachine.cs
+++ b/src/Utils/SkinModifierMachine.cs
@@ -1,14 +1,9 @@
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.PixelFormats;
 using OsuSkinMixer.Models;
 using OsuSkinMixer.Statics;
-using Godot;
 using Image = SixLabors.ImageSharp.Image;
 using Color = SixLabors.ImageSharp.Color;
 


### PR DESCRIPTION
Making use of the global modifier introduced in C#.

Also all local usings have been defined after each file-scoped namespace. This ensures that the local using always overrides the global using and ensures you won't run into for example should I be using Godot.Collections.Dictionary<T1, T2> or System.Collections.Generic.Dictioanry<T1, T2>.